### PR TITLE
Feature/update amex jest preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Extends [amex-jest-preset](https://github.com/americanexpress/amex-jest-preset) 
 
 - [moduleNameMapper](http://facebook.github.io/jest/docs/en/configuration.html#modulenamemapper-object-string-string) tells Jest to treat CSS modules as identity objects
 
-- [setupTestFrameworkScriptFile](http://facebook.github.io/jest/docs/en/configuration.html#setuptestframeworkscriptfile-string) is where we setup [enzyme with enzyme-adapter-react-16](http://airbnb.io/enzyme/docs/installation/react-16.html)
+- [setupFilesAfterEnv](http://facebook.github.io/jest/docs/en/configuration.html#setuptestframeworkscriptfile-string) is where we setup [enzyme with enzyme-adapter-react-16](http://airbnb.io/enzyme/docs/installation/react-16.html)
 
 - [snapshotSerializers](http://facebook.github.io/jest/docs/en/configuration.html#snapshotserializers-array-string) tells Jest to use [enzyme-to-json's](https://github.com/adriantoine/enzyme-to-json) serializer
 
@@ -39,7 +39,7 @@ And... that's it! You now have all the boilerplate Jest configurations set up fo
 
 You can add on and/or override any values provided in this preset as you wish in your [Jest configuration][].
 
-It should be noted that if overriding the `setupTestFrameworkScriptFile` you may want to extend off of the [setup file provided by amex-jest-preset-react](./jest-setup.js) in order to preserve that files' content. Otherwise you will lose anything we provide for you in [there](./jest-setup.js). Do so as follows:
+It should be noted that if overriding the `setupFilesAfterEnv` option you may want to extend off of the [setup file provided by amex-jest-preset-react](./jest-setup.js) in order to preserve that files' content. Otherwise you will lose anything we provide for you in [there](./jest-setup.js). Do so as follows:
 
 ```javascript
 // in custom-jest-setup.js
@@ -50,7 +50,7 @@ require('amex-jest-preset-react/jest-setup');
 
 ## Compatibility
 
-Version 4.x of this package is compatible only with React 16.
+This package is compatible only with React 16+.
 
 ## Contributing
 We welcome Your interest in the American Express Open Source Community on Github.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Extends [amex-jest-preset](https://github.com/americanexpress/amex-jest-preset) 
 
 - [moduleNameMapper](http://facebook.github.io/jest/docs/en/configuration.html#modulenamemapper-object-string-string) tells Jest to treat CSS modules as identity objects
 
-- [setupFilesAfterEnv](http://facebook.github.io/jest/docs/en/configuration.html#setuptestframeworkscriptfile-string) is where we setup [enzyme with enzyme-adapter-react-16](http://airbnb.io/enzyme/docs/installation/react-16.html)
+- [setupFilesAfterEnv](https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array) is where we setup [enzyme with enzyme-adapter-react-16](http://airbnb.io/enzyme/docs/installation/react-16.html)
 
 - [snapshotSerializers](http://facebook.github.io/jest/docs/en/configuration.html#snapshotserializers-array-string) tells Jest to use [enzyme-to-json's](https://github.com/adriantoine/enzyme-to-json) serializer
 

--- a/__tests__/__snapshots__/jest-preset.spec.js.snap
+++ b/__tests__/__snapshots__/jest-preset.spec.js.snap
@@ -31,7 +31,7 @@ Object {
     "npm-cache",
     ".npm",
   ],
-  "setupTestFrameworkScriptFile": Any<String>,
+  "setupFilesAfterEnv": Any<Array>,
   "snapshotSerializers": Array [
     "enzyme-to-json/serializer",
   ],

--- a/__tests__/jest-preset.spec.js
+++ b/__tests__/jest-preset.spec.js
@@ -2,7 +2,7 @@ test('a jest configuration is exported', () => {
   const jestPreset = require('../jest-preset');
 
   expect(jestPreset).toMatchSnapshot({
-    setupTestFrameworkScriptFile: expect.any(String),
+    setupFilesAfterEnv: expect.any(Array),
     testResultsProcessor: expect.any(String),
     cache: expect.any(Boolean)
   });

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -15,7 +15,7 @@
 const basePreset = require('amex-jest-preset');
 const reactSpecificPreset = {
   testEnvironment: 'jsdom',
-  setupTestFrameworkScriptFile: require.resolve('./jest-setup'),
+  setupFilesAfterEnv: [require.resolve('./jest-setup')],
   snapshotSerializers: ['enzyme-to-json/serializer'],
   moduleNameMapper: {
     '\\.(css|scss)$': 'identity-obj-proxy'

--- a/jest-setup.js
+++ b/jest-setup.js
@@ -12,8 +12,6 @@
  * the License.
  */
 
-require('amex-jest-preset/jest-setup');
-
 global.requestAnimationFrame = (callback) => {
   setTimeout(callback, 0);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amex-jest-preset-react",
-  "version": "5.0.3",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -840,22 +840,12 @@
         "react-is": "^16.9.0"
       }
     },
-    "ajv": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "requires": {
-        "co": "^4.6.0",
-        "json-stable-stringify": "^1.0.1"
-      }
-    },
     "amex-jest-preset": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/amex-jest-preset/-/amex-jest-preset-5.0.1.tgz",
-      "integrity": "sha512-Pbix9JMp6ThIfOok3GKRTit41ueiE1Q0bh5kOkgSNRCN6IpMv/vTFI8Df3bDP7YW4cUWY2E+/wctT6qOf1KijQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/amex-jest-preset/-/amex-jest-preset-6.0.0.tgz",
+      "integrity": "sha512-aVKUjMyGvGf324stFoW7Igqj25Q8yQdMZ9Od+btIDCzZMVq5MdwoNehrbWuNxHioR76q3NuKPxRozzsDwGWa+A==",
       "requires": {
         "is-ci": "^1.0.10",
-        "jest-json-schema": "^1.2.0",
         "mkdirp": "^0.5.1",
         "strip-ansi": "^3.0.1",
         "xmlbuilder": "^9.0.0"
@@ -870,12 +860,14 @@
     "ansi-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1402,6 +1394,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1480,7 +1473,8 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -1496,6 +1490,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1503,7 +1498,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -2040,7 +2036,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.12.1",
@@ -3117,7 +3114,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -3961,11 +3959,6 @@
         "jest-util": "^24.9.0"
       }
     },
-    "jest-get-type": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
-      "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w=="
-    },
     "jest-haste-map": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
@@ -4048,17 +4041,6 @@
         }
       }
     },
-    "jest-json-schema": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jest-json-schema/-/jest-json-schema-1.3.1.tgz",
-      "integrity": "sha512-SWGRyJIx6LhVOfjknsKjmIulnYKiSwtJr1g/ihWv9PxQtYbiOU3wT13XKLnVZzQewDs+0vU/TNItKwrQ7H0qaQ==",
-      "requires": {
-        "ajv": "^4.11.8",
-        "chalk": "^2.3.2",
-        "jest-matcher-utils": "^22.4.0",
-        "lodash": "^4.17.4"
-      }
-    },
     "jest-leak-detector": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
@@ -4093,16 +4075,6 @@
             "react-is": "^16.8.4"
           }
         }
-      }
-    },
-    "jest-matcher-utils": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
-      "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
-      "requires": {
-        "chalk": "^2.0.1",
-        "jest-get-type": "^22.4.3",
-        "pretty-format": "^22.4.3"
       }
     },
     "jest-message-util": {
@@ -4523,14 +4495,6 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -4553,11 +4517,6 @@
           "dev": true
         }
       }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -5604,15 +5563,6 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
-    "pretty-format": {
-      "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
-      "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
-      "requires": {
-        "ansi-regex": "^3.0.0",
-        "ansi-styles": "^3.2.0"
-      }
-    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -6533,6 +6483,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "amex-jest-preset-react",
   "description": "An opinionated Jest preset for React modules",
-  "version": "5.0.3",
+  "version": "6.0.0",
   "keywords": [
     "jest",
     "preset",
@@ -11,14 +11,14 @@
   ],
   "main": "jest-preset.js",
   "dependencies": {
-    "amex-jest-preset": "^5.0.1",
+    "amex-jest-preset": "^6.0.0",
     "enzyme": "^3.0.0",
     "enzyme-adapter-react-16": "^1.7.0",
     "identity-obj-proxy": "^3.0.0"
   },
   "peerDependencies": {
     "enzyme-to-json": "^3.0.1",
-    "jest": ">=23.0.0",
+    "jest": ">=24.0.0",
     "react": "^16.0.0",
     "react-test-renderer": "^16.0.0",
     "react-dom": "^16.0.0"
@@ -27,7 +27,7 @@
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
     "husky": "^3.1.0",
-    "jest": ">=23.0.0",
+    "jest": ">=24.0.0",
     "lockfile-lint": "^3.0.8"
   },
   "contributors": [


### PR DESCRIPTION
Updating the jest preset used as the base. This brings in breaking changes as jest-json-schema is no longer used. Also breaking in that we now use setUpFilesAfterEnv which requires jest 24 or above.