### PR TITLE
chore(packagejson): remove react-test-renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,8 @@
   "peerDependencies": {
     "enzyme-to-json": "^3.0.1",
     "jest": ">=24.0.0",
-    "react": ">=16 <19",
-    "react-test-renderer": ">=16 <19",
-    "react-dom": ">=16 <19"
+    "react": "16.x",
+    "react-dom": "16.x"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",


### PR DESCRIPTION
set the react peerDep to only 16

react-test-renderer is not used directly in this repo, and is not a peer dependency of enzyme or the 16 adapter.
