### PR TITLE
feat(jest-preset): collect coverage from typescript files

### DIFF
--- a/__tests__/__snapshots__/jest-preset.spec.js.snap
+++ b/__tests__/__snapshots__/jest-preset.spec.js.snap
@@ -6,7 +6,7 @@ Object {
   "cacheDirectory": "<rootDir>/.jest-cache",
   "collectCoverage": true,
   "collectCoverageFrom": Array [
-    "src/**/*.{js,jsx}",
+    "src/**/*.{js,jsx,ts,tsx}",
     "!**/node_modules/**",
     "!test-results/**",
   ],

--- a/jest-preset.js
+++ b/jest-preset.js
@@ -21,7 +21,7 @@ const reactSpecificPreset = {
     '\\.(css|scss)$': 'identity-obj-proxy'
   },
   collectCoverageFrom: [
-    'src/**/*.{js,jsx}',
+    'src/**/*.{js,jsx,ts,tsx}',
     '!**/node_modules/**',
     '!test-results/**'
   ]


### PR DESCRIPTION
## Description
Add `.ts` and `.tsx` extensions to the coverage.

## Motivation and Context
Given the common usage of Typescript, it's unexpected that they are not include in the coverage reporting.

## How Has This Been Tested?
Validated that this config properly collects coverage from typescript files.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [x] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using amex-jest-preset-react?
Developers using typescript will have proper coverage values reported.