### PR TITLE
fix: relax react peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
       },
       "peerDependencies": {
         "jest": ">=24.0.0",
-        "react": "^17.0.2||^18.2.0",
-        "react-dom": "^17.0.2||^18.2.0"
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   },
   "peerDependencies": {
     "jest": ">=24.0.0",
-    "react": "^17.0.2||^18.2.0",
-    "react-dom": "^17.0.2||^18.2.0"
+    "react": ">=16.0.0",
+    "react-dom": ">=16.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",


### PR DESCRIPTION
## Description
Allow any modern version of React as a peer dep.

## Motivation and Context
This package used to use `enzyme-adapter-react-16` and had a peer dep to react@16.
It was then updated to use `enzyme-adapter-react-17` and the peer dep was adjusted to react@17.  
Then the enzyme dependency was removed entirely, and the peer dep was adjust to react@17 or react@18.

But, practically speaking, there is no hard relationship to react at all anymore. It should work fine with react@16 or react@19.  So this PR removes the restrictions. 

## How Has This Been Tested?
Verified the semver matches the expected ranges.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] My changes are in sync with the code style of this project.
- [ ] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using amex-jest-preset-react?
Can use the package with more versions of React.